### PR TITLE
lib: use core_affinity instead of os for Cores

### DIFF
--- a/fuzzer-options/src/lib.rs
+++ b/fuzzer-options/src/lib.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use libafl::bolts::os::Cores;
+use libafl::bolts::core_affinity::Cores;
 
 #[cfg(feature = "libafl_qemu")]
 use libafl_qemu::filter_qemu_args;


### PR DESCRIPTION
When I'm using the 0.8.1 version of libafl, it turns out that Cores is under core_affinity instead of os. Exercise 1 is passed after fixing this.