### PR TITLE
compiler: use current_exe to locate libexerciseone

### DIFF
--- a/exercise-1/Makefile.toml
+++ b/exercise-1/Makefile.toml
@@ -23,7 +23,6 @@ dependencies = ["afl-clean", "clean-xpdf", "build-compilers", "build-xpdf", "bui
 [tasks.build-compilers]
 script = """
 cargo build --release
-cp -f ../target/release/libexerciseone.a .
 """
 
 [tasks.build-xpdf]

--- a/exercise-1/src/bin/compiler.rs
+++ b/exercise-1/src/bin/compiler.rs
@@ -2,7 +2,11 @@ use libafl_cc::{ClangWrapper, CompilerWrapper};
 use std::env;
 
 pub fn main() {
-    let cwd = env::current_dir().unwrap();
+    // Get current path of the compiler.
+    // This is also where the libexerciseone.a is placed.
+    let mut cwd = env::current_exe().unwrap();
+    cwd.pop();
+
     let args: Vec<String> = env::args().collect();
 
     let mut cc = ClangWrapper::new();


### PR DESCRIPTION
The current_dir will be different from the exe path is the compiler is called from another path. This brings errors when we configure the xpdf in exercise one. So we are changing it to current_exe and removing the manual `cp` in Makefile.toml.